### PR TITLE
Proposals on top of 2.0.0_001

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ revisioned ones:
 Note that files or directories not considered changed by Git are not updated,
 even if their metadata have been changed, and a `--store` is required to record
 their metadata changes in such cases. Though, conversely, this avoids
-unintentional metadata changes from being included, and could be preferrable in
+unintentional metadata changes from being included, and could be preferable in
 many cases.
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ to generate `pre-commit`, `post-checkout`, and `post-merge` hooks for the
 current Git repo. Of course you can modify the hooks afterwards to fit your
 needs better.
 
+You can use the `--fields` option together with `--install` to define which
+fields the pre-commit hook shall record when it creates a data file from
+scratch.
+
 Note that the installation is skipped to avoid a dangerous overwrite if there
 are existing hooks. In this case you can rename the existing hook files, run
 the installation again, and merge the hook contents manually. The `--force`

--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -406,7 +406,7 @@ sub get_file_metadata {
         "user"  => $user,
         "group" => $group,
         "acl"   => $acl,
-        "directory"   => "",
+        "directory"   => ".",
     );
     # output formatted data
     foreach (@fields) {

--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -903,7 +903,7 @@ sub main {
             exit;
         }
         if (!$argv{'force'} && `$GIT status --porcelain -uno -z 2>/dev/null` ne "") {
-          die "error: git working tree is not clean.\nCommit, stach, or revert changes before running this, or add --force.\n";
+          die "error: git working tree is not clean.\nCommit, stash, or revert changes before running this, or add --force.\n";
         }
         if (!$cache_file_accessible) {
             die "error: unable to access `$git_store_meta_file'.\n";

--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -222,7 +222,8 @@ exit 1
 git add %s
 EOF
     close(FILE);
-    chmod(0755, $t) == 1 || die "error: failed to set permissions on '$t': $!\n";
+    chmod(0777&~umask, $t) == 1
+	|| die "error: failed to set permissions on '$t': $!\n";
     print "created `$t'\n";
 
     $t = "$gitdir/hooks/post-checkout";
@@ -244,7 +245,8 @@ if [ ${sha_new} != ${sha_old} ]; then
 fi
 EOF
     close(FILE);
-    chmod(0755, $t) == 1 || die "error: failed to set permissions on '$t': $!\n";
+    chmod(0777&~umask, $t) == 1
+	|| die "error: failed to set permissions on '$t': $!\n";
     print "created `$t'\n";
 
     $t = "$gitdir/hooks/post-merge";
@@ -264,7 +266,8 @@ if [ $is_squash -eq 0 ]; then
 fi
 EOF
     close(FILE);
-    chmod(0755, $t) == 1 || die "error: failed to set permissions on '$t': $!\n";
+    chmod(0777&~umask, $t) == 1
+	|| die "error: failed to set permissions on '$t': $!\n";
     print "created `$t'\n";
 }
 

--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -426,6 +426,8 @@ sub store {
         }
         close(CMD);
         if ($fields_used{'directory'}) {
+	    my $s = join("\t", get_file_metadata(".", \@fields));  # Topdir.
+	    print TEMP_FILE "$s\n" if $s;
             open(CMD, "$GIT ls-tree -rd --name-only -z \$($GIT write-tree) |") or die;
             while(<CMD>) {
                 chomp;
@@ -517,6 +519,10 @@ sub update {
                 print TEMP_FILE escape_filename($file)."\0\2M\0\n";
             }
         }
+	# always update topdir when gathering directory data
+	if ($fields_used{'directory'}) {
+	    print TEMP_FILE ".\0\2M\0\n";
+	}
     }
     close(TEMP_FILE);
 


### PR DESCRIPTION
Thank you @danny0838 for the new alpha release 2.0.0_001, which introduces great improvements while keeping `git-store-meta.pl` lightweight and backward compatible. Impressive work!

After testing the release, I would like to propose minor changes that are best presented in form of a pull request&mdash;the one at hand. They come in the branch `proposals` as commits that can be applied individually by cherry picking.

The proposed changes cover the following topics:

1. **Include topdir into scope of directory field**
   The meta-data of the top directory (`.git/..`) of the working tree should also be recorded when storing directory data. This directory is definitely a part of the working tree and typically gets its meta-data changed on every checkout.

2. **Allow defining fields default for pre-commit at install time (#20)**
   For the cases in which the pre-commit hook script falls back to the `--store` command, i.e. when it has to generate a new meta-data file from scratch, it could be desirable to equip this `--store` with a `--field` option. This would just set some defaults without preventing the user from changing fields manually later or on a per branch basis.

   It would be convenient, if this could be specified at install time with a `--fields` option in the `--install` command, which just puts that option verbatim into the `--store` fallback in the pre-commit hook script.

   This is basically the idea that @lozobo brought up in issue #20.

3. **Respect umask on install**
   It would be nice to let the mode of the hook scrips be determined by the user's umask, i.e. to install the scripts with mode `0777&~umask`.

4. **Omit trailing whitespace in metadata file**
   Right now, when storing directory meta-data, the last field in the file entries is an empty dummy. This turns the last field separator `\t` into a trailing whitespace. On some systems, e.g. Magit, committing such contents attracts some attention, which would be false alarm in this case. Therefore it might be better to not leave the dummy field empty: The corresponding code in this pull request puts a period in there.

5. **Fix typos**
   Does exactly that.

What do you think?

Please leave a note if I should do some changes or anything else to support the pull.
