### PR TITLE
--timezone parameter

### DIFF
--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -13,9 +13,10 @@
 #   --version          Show current version and exit.
 #
 # Available OPTIONs are:
-#   -f|--fields FIELDs Fields to handle (see below). If omitted, fields in the
-#                      current metadata store file are picked when possible;
-#                      otherwise, "mtime" is picked as the default.
+#   -f|--fields FIELDs Fields to handle (see below) separated by comma. If
+#                      omitted, fields in the current metadata store file are
+#                      picked when possible; otherwise, "mtime" is picked as
+#                      the default.
 #                      (available for: --store, --apply)
 #   -d|--directory     Also store, update, or apply for directories.
 #                      (available for: --store, --apply)
@@ -35,6 +36,8 @@
 #   -t|--target FILE   Specify another filename to store metadata. Defaults to
 #                      ".git_store_meta" in the root of the working tree.
 #                      (available for: --store, --update, --apply, --install)
+#   -z|--timezone TZ   Specify the time zone to consider for dates in the form
+#                      of ±hh (for example -5, +2, -10, etc)
 #
 # FIELDs is a comma-separated string consisting of the following values:
 #   mtime   last modified time
@@ -117,6 +120,7 @@ my %argv = (
     "force"      => 0,
     "dry-run"    => 0,
     "verbose"    => 0,
+    "timezone"   => undef,
 );
 GetOptions(
     "store|s"      => \$argv{'store'},
@@ -132,6 +136,7 @@ GetOptions(
     "dry-run|n"    => \$argv{'dry-run'},
     "verbose|v"    => \$argv{'verbose'},
     "target|t=s"   => \$argv{'target'},
+    "timezone|z=s" => \$argv{'timezone'},
 ) or die;
 
 # determine action
@@ -366,14 +371,50 @@ sub get_file_type {
     return undef;
 }
 
+# Returns the timestamp set according to the --timezone parameter. If timezone
+# is not defined then it returns the original time.
+sub time_compensator {
+    my (@timestamp) = @_;
+    if (defined($argv{'timezone'})) {
+        my $timezone = int($argv{'timezone'});
+        if($timezone >= -12 && $timezone <= 14) {
+            my @lt = localtime(12*60*60);
+            my @gt = gmtime(12*60*60);
+            my $local_tz = $lt[2] - $gt[2];
+            my $range_time = 0;
+            # For cases where one time zone is negative and another is positive
+            for (my $i=($local_tz < $timezone ? $local_tz : $timezone); $i < ($local_tz > $timezone ? $local_tz : $timezone); $i++) {
+                $range_time++;
+            }
+            my $time_diff = abs(abs($timezone) - abs($local_tz));
+            if ($time_diff != $range_time) {
+                $time_diff = $range_time;
+            }
+            if ($timezone > $local_tz) {
+                $timestamp[2] = $timestamp[2] - $time_diff;
+            }
+            elsif ($timezone < $local_tz) {
+                $timestamp[2] = $timestamp[2] + $time_diff;
+            }
+            return @timestamp;
+        }
+        else {
+            die "error: incorrect timezone\n";
+        }
+    }
+    else {
+        return @timestamp;
+    }
+}
+
 sub timestamp_to_gmtime {
     my ($timestamp) = @_;
-    my @t = gmtime($timestamp);
+    my @t = time_compensator(gmtime($timestamp));
     return strftime("%Y-%m-%dT%H:%M:%SZ", @t);
 }
 
 sub gmtime_to_timestamp {
-    my ($gmtime) = @_;
+    my ($gmtime) = time_compensator(@_);
     $gmtime =~ m/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})Z$/;
     return timegm($6, $5, $4, $3, $2 - 1, $1);
 }


### PR DESCRIPTION
It occurred to me to add the `--timezone`/`-z` parameter because of [this issue](https://github.com/microsoft/MS-DOS/issues/413), although the idea is to use it in cases like the following:
1. Let's say that someone from Italy downloads a compressed archive from someone from Ukraine and creates a git repository with its content.
2. After the first commit, he want to save the modification date of the original files and execute git-store-meta.pl before starting to work with them.
3. When check the content of .git_store_meta he realize that the times on the dates do not correspond to those of Ukraine.

To make it clearer, download [this archive](https://github.com/danny0838/git-store-meta/files/4425624/repotest.zip), unzip it, run the command `perl .git/hooks/git-store-meta.pl --store -n` and compare the output with the saved .git_store_meta, you will probably see something like `test.txt	f	2020-04-02T19:23:50Z`.
This mismatch occurs because when unpacking a compressed archive the system usually assumes that the dates on the files correspond to the local time because the compressed archives do not retain the original time zone.
Since Perl doesn't have a transparent way to change the time zones in the timestamps (or if there is one then I haven't figured it out yet) I had to add the `time_compensator` function that does the corresponding adjustment.
I was testing it with the repository of this script and with another one I'm working on and it seems to work fine (even so I don't rule out that there might be undiscovered errors). Something I noticed is that when using `--timezone` together with `--update`, the adjustment in the dates is not maintained, any idea why this is?
It should be noted that `--timezone` does not take into account [unusual time zones](https://www.worldtimeserver.com/learn/unusual-time-zones/) nor summer/winter time, but should be sufficient for most cases.