### PR TITLE
Samir

### DIFF
--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -52,7 +52,7 @@
 #   gid     group ID (if group is also set, prefer group and fallback to gid)
 #   acl     access control lists for POSIX setfacl/getfacl
 #
-# git-store-meta 2.3.6
+# git-store-meta 2.3.6.1
 # Copyright (c) 2015-2022, Danny Lin
 # Released under MIT License
 # Project home: https://github.com/danny0838/git-store-meta
@@ -62,7 +62,7 @@ use utf8;
 use strict;
 use warnings;
 
-use version; our $VERSION = version->declare("v2.3.6");
+use version; our $VERSION = version->declare("v2.3.6.1");
 use Getopt::Long;
 Getopt::Long::Configure qw(gnu_getopt);
 use File::Basename;

--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -681,7 +681,7 @@ git_store_meta() (
     sha_old=$1; sha_new=$2; change_br=$3
 
     # apply metadata only when HEAD is changed
-    [ ${sha_new} == ${sha_old} ] && return
+    [ "${sha_new}" = "${sha_old}" ] && return
 
     "$script" --apply%2$s
 )


### PR DESCRIPTION
hi, i was using your script (v 2.3.6) in ubuntu 20.04.
Every time I switched branches, I was getting this error:

.git/hooks/post-checkout: 7: [: commit hash: unexpected operator

After investigating the post-checkout hook I found that it was using '==' comparison operator which is not recognized by built-in test '[ ]'  /bin/sh in ununtu.

I changed it to use '=' operator which is posix-compliant and works in both sh and bash

I also added double quotes around variables to prevent globbing (although it's not a risk here since we are dealing with hexadecimal hashes)

I don't know if it's appropriate or not, but I added ".1" suffix to the version no in order to make it easy to know which version is being used.  I suppose you will change that to whatever version is appropriate for you (probably 2.3.7?)

Please feel free to modify my edit if you need to.

Thank you for your valuable work.  The script has helped me considerably,

Best regards,
Samir Noman
