### PR TITLE
Add error info to get_cache_header_info and display it to end user

### DIFF
--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -743,7 +743,9 @@ sub get_cache_header_info_orig {
     $line or return "empty second line";
     chomp($line);
     foreach (split("\t", $line)) {
-        m/^<(.*)>$/ and push(@cache_fields, $1) or return "invalid field '$_' in header line: '$line'";
+        m/^<([a-z]+)>$/ or return "invalid field '$_' in header line: '$line'";
+        grep(/^$1$/, @FIELDS) or return "invalid field name '$_' in header line: '$line'";
+        push(@cache_fields, $1);
     }
 
     # check for existence of "file" and "type" fields


### PR DESCRIPTION
when using a git repo, I sometimes encounter the error:

> .git_store_meta is malformatted.
> Fix it or run --store to create new

And by inspecting the file it's not clear why! 
These errors seem like random (I haven't been able to find what causes them)!

So, I made a modification to return a meaningful error from the function get_cache_header_info and display it.  This should help disagnose these errors in the future in order to be able to solve them quickly
