### PR TITLE
place a placeholder for $VERSION in help text and replace it when displaying usage

### DIFF
--- a/git-store-meta.pl
+++ b/git-store-meta.pl
@@ -52,7 +52,7 @@
 #   gid     group ID (if group is also set, prefer group and fallback to gid)
 #   acl     access control lists for POSIX setfacl/getfacl
 #
-# git-store-meta 2.3.7
+# git-store-meta $VERSION
 # Copyright (c) 2015-2023, Danny Lin
 # Released under MIT License
 # Project home: https://github.com/danny0838/git-store-meta
@@ -584,6 +584,8 @@ sub setfacl_external {
 # with "# " removed
 sub usage {
     my $start = 0;
+    my $version = $VERSION;
+    $version =~ s/^v//;  # remove optional starting 'v'
     open(GIT_STORE_META, "<:crlf", $script)
         or die "error: failed to access `$script': $!\n";
     while (<GIT_STORE_META>) {
@@ -593,6 +595,7 @@ sub usage {
         }
         next if !$start;
         s/^# ?//;
+        s/\$VERSION/$version/; # replace $VERSION with actual version
         print;
     }
     close(GIT_STORE_META);


### PR DESCRIPTION
This is a minor change which may help maintaining the version number.  Right now, the version number text appears in two places in the file:

* at the end of the Usage message; which is placed at the top of the file
* when assiging $VERSION variable

This change places a placeholder in the Usage message ($VERSION , but could be anything `__VERSION__`, {VERSION}, ... etc)
and in function usage, it will be replaced by $VERSION


